### PR TITLE
docs: Fix simple typo, pais -> pairs

### DIFF
--- a/dist/buckets.js
+++ b/dist/buckets.js
@@ -1125,7 +1125,7 @@
         };
 
         /**
-         * Returns the number of key-value pais in the dictionary.
+         * Returns the number of key-value pairs in the dictionary.
          * @return {number} The number of key-value mappings in the dictionary.
          */
         dictionary.size = function () {

--- a/src/dictionary.js
+++ b/src/dictionary.js
@@ -164,7 +164,7 @@ buckets.Dictionary = function (toStrFunction) {
     };
 
     /**
-     * Returns the number of key-value pais in the dictionary.
+     * Returns the number of key-value pairs in the dictionary.
      * @return {number} The number of key-value mappings in the dictionary.
      */
     dictionary.size = function () {


### PR DESCRIPTION
There is a small typo in dist/buckets.js, src/dictionary.js.

Should read `pairs` rather than `pais`.

